### PR TITLE
key: decrement key_is_grabbed release of multi-Alt

### DIFF
--- a/src/key.c
+++ b/src/key.c
@@ -57,10 +57,13 @@ void vwm_key_released(vwm_t *vwm, Window win, XKeyReleasedEvent *keyrelease)
 			VWM_TRACE("XK_Alt_[LR] released");
 
 			/* aborted? try restore focused_origin */
-			if (key_is_grabbed > 1 && vwm->focused_origin) {
-				VWM_TRACE("restoring %p on %p", vwm->focused_origin, vwm->focused_origin->desktop);
-				vwm_desktop_focus(vwm, vwm->focused_origin->desktop);
-				vwm_win_focus(vwm, vwm->focused_origin);
+			if (key_is_grabbed > 1) {
+				key_is_grabbed--;	/* This is important to prevent treating the final lone Alt release as another cancel/rollback. */
+				if (vwm->focused_origin) {
+					VWM_TRACE("restoring %p on %p", vwm->focused_origin, vwm->focused_origin->desktop);
+					vwm_desktop_focus(vwm, vwm->focused_origin->desktop);
+					vwm_win_focus(vwm, vwm->focused_origin);
+				}
 			}
 
 			/* make the focused window the most recently used */


### PR DESCRIPTION
Upon releasing all keys concluding a grab the counter gets reset so this isn't
generally observed as being a problem.

Sometimes the second Alt is released by itself, restoring the origin, and the
original grabbing single Alt persists for subsequent window management
operations.  It's in this situation when the bug manifests.  If the final Alt
release occurred with a focused window/desktop differing from the origin, on
the final Alt release an unexpected restore to the origin occurred.

Usually this goes unnoticed, because typically the lone Alt release occurs
immediately following the other one, and the second restore to origin happens
to be idempotent.