### PR TITLE
Trivial cleanup and small (but continuous) memory leak fix

### DIFF
--- a/src/composite.c
+++ b/src/composite.c
@@ -173,7 +173,7 @@ void vwm_composite_paint_all(vwm_t *vwm)
 {
 	vwm_xwindow_t		*xwin;
 	XRenderColor		bgcolor = {0x0000, 0x00, 0x00, 0xffff};
-	Region			occluded = XCreateRegion();
+	Region			occluded;
 	static XserverRegion	undamage_region = None;
 
 	/* if there's no damage to repaint, short-circuit, this happens when compositing for overlays is disabled. */
@@ -196,6 +196,7 @@ void vwm_composite_paint_all(vwm_t *vwm)
 		XFreePixmap(vwm->display, root_pixmap);
 	}
 
+	occluded = XCreateRegion();
 	/* compose overlays for all visible windows up front in a separate pass (kind of lame, but it's simpler since compose_overlay() adds to combined_damage) */
 	list_for_each_entry_prev(xwin, &vwm->xwindows, xwindows) {
 		XRectangle	r;

--- a/src/key.c
+++ b/src/key.c
@@ -97,7 +97,6 @@ void vwm_key_pressed(vwm_t *vwm, Window win, XKeyPressedEvent *keypress)
 	static typeof(keypress->state)		last_state;
 	static int				repeat_cnt = 0;
 	int					do_grab = 0;
-	char					*quit_console_args[] = {"/bin/sh", "-c", "screen -dr " CONSOLE_SESSION_STRING " -X quit", NULL};
 
 	sym = XLookupKeysym(keypress, 0);
 
@@ -174,10 +173,8 @@ void vwm_key_pressed(vwm_t *vwm, Window win, XKeyPressedEvent *keypress)
 		case XK_Escape: /* leave VWM rudely, after triple press */
 			do_grab = 1;
 
-			if (repeat_cnt == 2) {
-				vwm_launch(vwm, quit_console_args, VWM_LAUNCH_MODE_FG);
-				exit(42);
-			}
+			if (repeat_cnt == 2)
+				vwm->done = 1;
 			break;
 
 		case XK_v: /* instantiate (and focus) a new (potentially empty, unless migrating) virtual desktop */

--- a/src/vwm.c
+++ b/src/vwm.c
@@ -69,11 +69,11 @@ static int errhandler(Display *display, XErrorEvent *err)
 int main(int argc, char *argv[])
 {
 	int		err = 0;
-	int		done = 0;
 	XEvent		event;
 	Cursor		pointer;
 	struct pollfd	pfd;
 	char		*console_args[] = {"xterm", "-class", CONSOLE_WM_CLASS, "-e", "/bin/sh", "-c", "screen -D -RR " CONSOLE_SESSION_STRING, NULL};
+	char		*quit_console_args[] = {"/bin/sh", "-c", "screen -dr " CONSOLE_SESSION_STRING " -X quit", NULL};
 
 #define reterr_if(_cond, _fmt, _args...) \
 	err++;\
@@ -168,7 +168,7 @@ int main(int argc, char *argv[])
 	pfd.revents = 0;
 	pfd.fd = ConnectionNumber(vwm.display);
 
-	while (!done) {
+	while (!vwm.done) {
 		do {
 			int	delay;
 
@@ -282,6 +282,9 @@ int main(int argc, char *argv[])
 
 		vwm_composite_paint_all(&vwm);
 	}
+
+	/* tear down console */
+	vwm_launch(&vwm, quit_console_args, VWM_LAUNCH_MODE_FG);
 
 	/* close connection to server */
 	XFlush(vwm.display);

--- a/src/vwm.h
+++ b/src/vwm.h
@@ -53,6 +53,7 @@ typedef struct _vwm_t {
 	Atom			wm_protocols_atom;
 	Atom			wm_pid_atom;
 	int			damage_event, damage_error;
+	int			done;			/* global flag to cause vwm to quit */
 
 	list_head_t		desktops;		/* global list of all (virtual) desktops in spatial created-in order */
 	list_head_t		desktops_mru;		/* global list of all (virtual) desktops in MRU order */


### PR DESCRIPTION
Tidy up vwm exit handling and stop leaking an X Region on every clean vwm_composite_paint_all().

If you noticed very long-running vwm instances hogging memory like a web browser, this is the culprit, vwm doesn't typically need much memory.